### PR TITLE
fix: improved display of algorithm execution cost

### DIFF
--- a/src/components/react/CostEstimateSideNavItem.tsx
+++ b/src/components/react/CostEstimateSideNavItem.tsx
@@ -49,11 +49,7 @@ export const CostEstimateSideNavItem = ({
   } else if (status === "success" && data?.length) {
     displayedCostEstimate = getAverageCostPerKm(data);
   }
-  console.log(
-    "CostEstimateSideNavItem - displayedCostEstimate:",
-    data,
-    displayedCostEstimate,
-  );
+
   const isEnabled = isFeatureEnabled(window.location.href, "costAnalysis");
 
   return (

--- a/src/components/react/CostEstimateSideNavItem.tsx
+++ b/src/components/react/CostEstimateSideNavItem.tsx
@@ -21,7 +21,10 @@ export const CostEstimateSideNavItem = ({
     try {
       const result = await getBenchmarkDetails(serviceId);
       if (result) {
-        setData(result.data);
+        setData(result.data.filter(item => item.costs > 0 && item.area_size > 0));
+        setStatus("success");
+      } else {
+        setData([]);
         setStatus("success");
       }
     } catch (error) {
@@ -31,25 +34,26 @@ export const CostEstimateSideNavItem = ({
   };
 
   useEffect(() => {
-    if (!costEstimate) {
-      fetchData();
-    }
+    fetchData();
   }, [serviceId]);
 
   let displayedCostEstimate = costEstimate ?? "-";
 
-  if (!costEstimate) {
-    if (status === "loading") {
-      displayedCostEstimate = "Loading cost estimate data...";
-    } else if (status === "error") {
-      displayedCostEstimate = "Failed to load cost estimate data.";
-    } else if (status === "success" && !data?.length) {
-      displayedCostEstimate = "No recent cost estimate data found.";
-    } else if (status === "success" && data?.length) {
-      displayedCostEstimate = getAverageCostPerKm(data);
-    }
+  if (status === "loading") {
+    displayedCostEstimate = "Loading cost estimate data...";
+  } else if (status === "error") {
+    displayedCostEstimate = "Failed to load cost estimate data.";
+  } else if (status === "success" && !data?.length) {
+    displayedCostEstimate =
+      costEstimate ?? "No recent cost estimate data found.";
+  } else if (status === "success" && data?.length) {
+    displayedCostEstimate = getAverageCostPerKm(data);
   }
-
+  console.log(
+    "CostEstimateSideNavItem - displayedCostEstimate:",
+    data,
+    displayedCostEstimate,
+  );
   const isEnabled = isFeatureEnabled(window.location.href, "costAnalysis");
 
   return (

--- a/src/components/react/ExecutionInfoTabs.tsx
+++ b/src/components/react/ExecutionInfoTabs.tsx
@@ -175,7 +175,7 @@ const getDateRange = (data: BenchmarkData[] | undefined) => {
 
 export const getAverageCostPerKm = (data: BenchmarkData[]) => {
   if (!data.length) return "-";
-  const totalCost = data.reduce(
+  const totalCost = data.filter(item => item.area_size > 0).reduce(
     (sum, item) => sum + item.costs / item.area_size,
     0,
   );
@@ -202,7 +202,7 @@ const CostAnalysisContent = ({
     try {
       const result = await getBenchmarkDetails(serviceId);
       if (result) {
-        setData(result.data);
+        setData(result.data.filter(item => item.costs > 0 && item.area_size > 0));
         setStatus("success");
       }
     } catch (error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,14 +15,14 @@ export const getBenchmarkSummary = async () => {
   }
 };
 
-export const getBenchmarkDetails = async (scenarioId: string) => {
+export const getBenchmarkDetails = async (scenarioId: string): Promise<BenchmarkDetails | undefined> => {
   try {
     // TODO: get multiple scenarios in one request
     // This should have received service / algorithm id instead of scenario id
     const response = await fetch(`/api/services/${scenarioId}/benchmarks.json`);
     if (response.ok) {
       return (await response.json()) as BenchmarkDetails;
-    }
+    } 
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
We have found the following issues with the cost estimation display in the APEx Algorithm Catalogue:

- Whenever the benchmarks had run, the actual cost estimation was never shown in the sidebar. This is a change of behaviour compared to the implemented one. This has been updated to always show the benchmark average, if available, and use the cost estimate from the record as a backup.
- Cost analysis and benchmark average cost estimation were also including benchmarks where the size sometimes was 0. Resulting in "Inifinity credits per km2". This has been fixed by filtering out these benchmarks whenever a cost is calculated.